### PR TITLE
Add GTFS and NeTEx feeds for France

### DIFF
--- a/feeds.toml
+++ b/feeds.toml
@@ -50,6 +50,18 @@
   infoUrl = "https://developer.matka.fi/pages/en/home.php"
 
 [[gtfsFeeds]]
+  countryIso = "fr"
+  licence = "ODbL"
+  attribution = "SNCF"
+  feedUrl = "https://eu.ftp.opendatasoft.com/sncf/gtfs/export_gtfs_voyages.zip"
+  infoUrl = "https://ressources.data.sncf.com/explore/dataset/horaires-des-train-voyages-tgvinouiouigo/information/"
+  comments = """
+This is for fast speed train only (TGV) data.
+Regional trains can be access very similarly here: https://ressources.data.sncf.com/explore/dataset/sncf-ter-gtfs/table/
+and here: https://ressources.data.sncf.com/explore/dataset/sncf-intercites-gtfs/table/
+  """
+
+[[gtfsFeeds]]
   countryIso = "ie"
   license = "CC-BY 4.0"
   attribution = "Transport for Ireland"
@@ -112,6 +124,18 @@
   infoUrl = "https://www.opendata-oepnv.de/ht/de/organisation/delfi/startseite?tx_vrrkit_view%5Bdataset_name%5D=deutschlandweite-sollfahrplandaten&tx_vrrkit_view%5Bdataset_formats%5D%5B0%5D=ZIP&tx_vrrkit_view%5Baction%5D=details&tx_vrrkit_view%5Bcontroller%5D=View"
   comments = """
   The official feed is hidden behind a login form, so the download URL points to a community mirror, which doesn't have any official SLAs.
+  """
+
+[[netexFeeds]]
+  countryIso = "fr"
+  license = "ODbL"
+  attribution = "SNCF"
+  feedUrl = "https://eu.ftp.opendatasoft.com/sncf/horaires/export-voyages-netex-last.zip"
+  infoUrl = "https://ressources.data.sncf.com/explore/dataset/horaires-des-train-voyages-tgvinouiouigo/information/"
+  comments = """
+This is for fast speed train only (TGV) data.
+Regional trains can be access very similarly here: https://ressources.data.sncf.com/explore/dataset/sncf-ter-gtfs/table/
+and here: https://ressources.data.sncf.com/explore/dataset/sncf-intercites-gtfs/table/
   """
 
 [[netexFeeds]]


### PR DESCRIPTION
SNCF (national railway company) offers feeds under the [ODbL
licence](https://data.sncf.com/pages/cgu/A1#A1).

There are three different feeds depending on the kind of train.
I added the ones for TGVs (high speed trains) as it made more sense
with the international nature of the project. I added the two other
feeds in the comments.

Please let me know if I can help further with the integration of French
feeds.